### PR TITLE
Support choosing pass by const/ref

### DIFF
--- a/include/details/Common.h
+++ b/include/details/Common.h
@@ -1,4 +1,6 @@
 #pragma once
+#include "Utils.h"
+#include <type_traits>
 
 namespace decision_tree { namespace details {
     
@@ -7,4 +9,56 @@ namespace decision_tree { namespace details {
         RangeCheck,             // compare attribute with target which is range<attr_type> (like vector)
         CustomCheck             // compare by a custom comparator which takes CheckT directly
     };
+
+    enum class PassBy {
+        Default,
+        Value,
+        ConstValue,
+        Reference,
+        ConstRef
+    };
+
+    namespace utils {
+        template<typename T, PassBy P>
+        constexpr static bool passByRef() {
+            return P == PassBy::ConstRef || P == PassBy::Reference || (P == PassBy::Default && std::is_class_v<T>);
+        }
+        
+        template<typename T, PassBy P>
+        constexpr static bool passByConst() {
+            return P == PassBy::ConstRef || P == PassBy::ConstValue || (P == PassBy::Default && std::is_class_v<T>);
+        }
+        
+        template<typename T, PassBy P>
+        struct PassByItem {
+            using type = T;
+            constexpr static PassBy value = P;
+        };
+
+        template<typename ...Args>
+        struct PassByRef_helper;
+        template<typename Head>
+        struct PassByRef_helper<Head> {
+            using type = std::conditional_t<utils::passByRef<typename Head::type, Head::value>(),
+                                            std::tuple<typename Head::type>, std::tuple<>>;
+        };
+        template<typename Head, typename ...Args>
+        struct PassByRef_helper<Head, Args...> {
+            using type = std::conditional_t<utils::passByRef<typename Head::type, Head::value>(),
+                                            utils::append_tuple_t<typename Head::type, typename PassByRef_helper<Args...>::type>, typename PassByRef_helper<Args...>::type>;
+        };
+
+        template<typename ...Args>
+        struct PassByConst_helper;
+        template<typename Head>
+        struct PassByConst_helper<Head> {
+            using type = std::conditional_t<utils::passByConst<typename Head::type, Head::value>(),
+                                            std::tuple<typename Head::type>, std::tuple<>>;
+        };
+        template<typename Head, typename ...Args>
+        struct PassByConst_helper<Head, Args...> {
+            using type = std::conditional_t<utils::passByConst<typename Head::type, Head::value>(),
+                                            utils::append_tuple_t<typename Head::type, typename PassByConst_helper<Args...>::type>, typename PassByConst_helper<Args...>::type>;
+        };
+    }
 }}

--- a/include/details/Utils.h
+++ b/include/details/Utils.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "Common.h"
 #include <type_traits>
 #include <utility>
 #include <cassert>
@@ -19,6 +18,20 @@ namespace decision_tree { namespace details { namespace utils {
     struct has_type;
     template <typename T, typename... Us>
     struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...> {};
+
+    /*
+        append type to tuple types
+    */
+    template<typename T, typename Tuple>
+    struct append_tuple;
+    template<typename T, template<typename ...Args> typename Tuple, typename ...Args>
+    struct append_tuple<T, Tuple<Args...>> {
+        using type = Tuple<Args..., T>;
+    };
+    template<typename T, typename Tuple>
+    using append_tuple_t = typename append_tuple<T, Tuple>::type;
+
+    using a = append_tuple_t<int, std::tuple<char, double>>;
 
     /* 
         a compile time switch case


### PR DESCRIPTION
* User can choose the default pass-by behavior for each registered type

When using `RegisterMetaType`, we need to supply the pass-by behavior for each type as the 3rd parameter. You can use `PassBy::Default` which indicates class would be passed by `const&` and other type by value