### PR TITLE
Performance optimization

### DIFF
--- a/example/TestMetaData.h
+++ b/example/TestMetaData.h
@@ -41,7 +41,6 @@ RegisterMetaType(Test, Data,
     ((double,       DOUBLE,         PassBy::Default,        ))
     ((std::string,  STRING,         PassBy::Default,        [](const std::string& s1, const std::string& s2) { return s1 == s2; }))
     ((std::vector<int>, INT_VEC,    PassBy::ConstRef,       ))
-    ((Data,         DataStruct,     PassBy::ConstRef,       [](const auto& d1, const auto& d2) { return d1.id == d2.id; }))
 );
 
 namespace decision_tree { namespace details {

--- a/include/DecisionTree.h
+++ b/include/DecisionTree.h
@@ -62,32 +62,37 @@ namespace decision_tree {
             auto size = _checks.size();
             for (auto& rule : _rules) {
                 rule._posMask.resize(size, 0);
-                rule._negMask.resize(size, 0);
                 for (auto check : rule._checks) {
                     rule._posMask.set(posMap[check], true);
                 }
             }
 
+            _mask.resize(_checks.size(), false);
+            _maskRes.resize(_checks.size(), false);
             return true;
         }
 
         void apply(const CheckT& t, std::vector<ReturnT>& ret) {
             // iterate over all the checks and return data in the hit rules
-            boost::dynamic_bitset<> mask(_checks.size());
+            _mask.reset();
             for (int i=0; i<_checks.size(); i++) {
                 auto res = MetaDataUtil::applyCheck(t, _checks[i]);
-                mask.set(i, res);
+                _mask.set(i, res);
             }
+            _maskRes = _mask;
             for (auto& rule : _rules) {
-                if (((mask & rule._posMask) == rule._posMask) &&
-                    ((~mask & rule._negMask) == rule._negMask))
+                _mask &= rule._posMask;
+                if (_mask == rule._posMask)
                 {
                     ret.push_back(rule._data);
                 }
+                _mask = _maskRes;
             }
         }
 
     private:
+        boost::dynamic_bitset<> _mask;
+        boost::dynamic_bitset<> _maskRes;
 
         /* data */
         std::vector<RuleType> _rules;

--- a/include/Rule.h
+++ b/include/Rule.h
@@ -18,7 +18,6 @@ namespace decision_tree {
             std::vector<ConditionCheck*> _checks;
             DataType _data;
             boost::dynamic_bitset<> _posMask;           // mark checks that should be true
-            boost::dynamic_bitset<> _negMask;           // mark checks that should be false
         };
     }
 

--- a/include/details/MetaData.h
+++ b/include/details/MetaData.h
@@ -84,10 +84,10 @@ namespace decision_tree { namespace details {
 #define MetaDataTypeTupleMakeItem(_, DATA, x)   BuildTuple(DATA, SelectElem_0(_, _, x), SelectElem_2(_, _, x))
 #define MetaDataTypeTupleMakeItems(_, DATA, x)  BuildTuple(DATA, SelectElem_0(_, _, x), SelectElem_2(_, _, x)),
 
-#define MetaDataTypeTupleDef(Seq)                           \
+#define MetaDataTypeTupleDef(Seq, TYPE)                     \
     using AllTypes = std::tuple<AllElems(Seq, _, SelectElem_0, SelectElems_0)>; \
-    using PassByRef = typename utils::PassByRef_helper<AllElems(Seq, utils::PassByItem, MetaDataTypeTupleMakeItem, MetaDataTypeTupleMakeItems)>::type;    \
-    using PassByConst = typename utils::PassByConst_helper<AllElems(Seq, utils::PassByItem, MetaDataTypeTupleMakeItem, MetaDataTypeTupleMakeItems)>::type;
+    using PassByRef = typename utils::PassByRef_helper<utils::PassByItem<TYPE, PassBy::Default>, AllElems(Seq, utils::PassByItem, MetaDataTypeTupleMakeItem, MetaDataTypeTupleMakeItems)>::type;    \
+    using PassByConst = typename utils::PassByConst_helper<utils::PassByItem<TYPE, PassBy::Default>, AllElems(Seq, utils::PassByItem, MetaDataTypeTupleMakeItem, MetaDataTypeTupleMakeItems)>::type;
 
 
 /*  tuple of Comparator for each registered type    */
@@ -110,7 +110,7 @@ namespace decision_tree { namespace details {
 
 /*  MetaData class body impl    */
 #define MetaDataBodyImpl(Type, Seq)                                 \
-    MetaDataTypeTupleDef(Seq)                                       \
+    MetaDataTypeTupleDef(Seq, Type)                                 \
     MetaDataTypeEnumDef(Seq)                                        \
     MetaDataCompDef(Seq)                                            \
     MetaDataGetTypeNameDef(Seq)                                     \


### PR DESCRIPTION
* Optimize performance by avoiding dynamic memory allocation caused by `dynamic_bitset`
* Set `PassBy::Default` for `CheckT`